### PR TITLE
Implement flip interaction for finished raffle cards

### DIFF
--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -2040,6 +2040,69 @@ footer {
 .raffle-card--finished .card-actions {
   grid-template-columns: 1fr;
 }
+
+.raffle-card--finished[role="button"] {
+  cursor: pointer;
+}
+
+.raffle-card--finished[role="button"]:focus-visible {
+  outline: 3px solid rgba(185, 141, 35, 0.45);
+  outline-offset: 4px;
+}
+
+.raffle-card--finished .raffle-card__flip {
+  position: relative;
+  min-height: 100%;
+  perspective: 1200px;
+}
+
+.raffle-card--finished .raffle-card__flip-inner {
+  position: relative;
+  min-height: 100%;
+  transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
+  transform-style: preserve-3d;
+}
+
+.raffle-card--finished.raffle-card--show-prizes .raffle-card__flip-inner {
+  transform: rotateY(180deg);
+}
+
+.raffle-card--finished .raffle-card__side {
+  position: relative;
+  backface-visibility: hidden;
+}
+
+.raffle-card--finished .raffle-card__side--back {
+  position: absolute;
+  inset: 0;
+  transform: rotateY(180deg);
+}
+
+.raffle-card--finished .raffle-card__side-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.raffle-card--finished .raffle-card__info {
+  flex: 1 1 260px;
+  min-width: 220px;
+}
+
+.raffle-card--finished .raffle-card__cta {
+  flex: 0 0 180px;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.raffle-card--finished .raffle-card__cta .button {
+  width: 100%;
+}
 /* ==== Gestionar sorteos: UI premium y responsive ==== */
 
 .admin-manage {

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -697,8 +697,13 @@ main {
 
 /* Estado finalizado */
 .raffle-card--finished {
-  border-color: rgba(78, 164, 234, 0.6);
-  background: linear-gradient(180deg, #ffffff 0%, var(--brand-50) 100%);
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+.raffle-card--finished::after {
+  content: none;
 }
 
 /* ============================
@@ -1948,23 +1953,6 @@ footer {
   margin: 0;
 }
 
-/* Evita que el contenido se recorte en el borde de la card */
-.card,
-.raffle-card {
-  overflow: visible; /* <- si hoy está en hidden, cámbialo a visible */
-  height: auto; /* <- asegúrate de no tener un alto fijo */
-}
-
-/* Si usaste contain para optimizar pintura, quítalo en finalizados */
-.raffle-card--finished {
-  contain: none; /* <- si existía contain: content/layout/paint */
-}
-
-.raffle-card--finished .card__body,
-.raffle-card--finished .raffle-card__content {
-  max-height: none; /* <- anula cualquier límite anterior */
-}
-
 /* Hace que el texto del ganador pueda truncar con elipsis */
 .winner-row {
   display: grid;
@@ -1998,7 +1986,6 @@ footer {
 .card,
 .raffle-card {
   height: auto !important; /* anula height:100% / min-height fijos */
-  overflow: hidden; /* contenido contenido dentro de la card */
   box-sizing: border-box;
 }
 
@@ -2050,10 +2037,38 @@ footer {
   outline-offset: 4px;
 }
 
+.raffle-card--finished {
+  overflow: visible;
+}
+
+.raffle-card__shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.raffle-card__shell--finished {
+  background: linear-gradient(
+    90deg,
+    rgba(247, 215, 116, 0.14) 0%,
+    rgba(255, 255, 255, 0.92) 100%
+  );
+  border: 1px solid rgba(185, 141, 35, 0.28);
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  min-height: 100%;
+  padding: 1rem;
+}
+
 .raffle-card--finished .raffle-card__flip {
   position: relative;
   min-height: 100%;
   perspective: 1200px;
+  overflow: visible;
+  transition: height var(--transition-slow, 0.28s ease);
 }
 
 .raffle-card--finished .raffle-card__flip-inner {
@@ -2070,6 +2085,7 @@ footer {
 .raffle-card--finished .raffle-card__side {
   position: relative;
   backface-visibility: hidden;
+  display: flex;
 }
 
 .raffle-card--finished .raffle-card__side--back {

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -628,6 +628,21 @@ main {
   background: linear-gradient(180deg, #2c78ca 0%, #1b5ca6 100%);
 }
 
+.button--gold {
+  background: linear-gradient(180deg, #f7d774 0%, #e9b949 100%);
+  color: #3b2f0b;
+  box-shadow: 0 10px 24px rgba(233, 185, 73, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.38);
+  border: 1px solid rgba(185, 141, 35, 0.35);
+}
+.button--gold:hover {
+  background: linear-gradient(180deg, #f4cd5d 0%, #dca53a 100%);
+}
+.button--gold:focus-visible {
+  outline: 3px solid rgba(185, 141, 35, 0.45);
+  outline-offset: 3px;
+}
+
 .button--ghost {
   background: transparent;
   border: 1px solid var(--border-strong);
@@ -1912,6 +1927,7 @@ footer {
 .raffle-card__shell--finished {
   --raffle-finished-shell-padding-block: clamp(1rem, 2vw, 1.25rem);
   --raffle-finished-shell-padding-inline: clamp(1rem, 2vw, 1.2rem);
+  --raffle-finished-shell-padding-bottom: clamp(1.65rem, 3vw, 2.35rem);
   background: linear-gradient(
     90deg,
     rgba(247, 215, 116, 0.14) 0%,
@@ -1923,7 +1939,7 @@ footer {
   min-height: 100%;
   padding: var(--raffle-finished-shell-padding-block)
     var(--raffle-finished-shell-padding-inline);
-  padding-bottom: calc(var(--raffle-finished-shell-padding-block) + 0.65rem);
+  padding-bottom: var(--raffle-finished-shell-padding-bottom);
   /* * Este colchón extra evita que el botón "Ver sorteo" choque con el borde. */
 }
 
@@ -1976,12 +1992,16 @@ footer {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   gap: 0.6rem;
+  width: min(100%, 18rem);
+  margin-inline: auto;
 }
 
 .raffle-card--finished .raffle-card__cta .button {
   width: 100%;
+  max-width: 16rem;
+  margin-inline: auto;
 }
 /* ==== Gestionar sorteos: UI premium y responsive ==== */
 

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -1910,6 +1910,8 @@ footer {
 }
 
 .raffle-card__shell--finished {
+  --raffle-finished-shell-padding-block: clamp(1rem, 2vw, 1.25rem);
+  --raffle-finished-shell-padding-inline: clamp(1rem, 2vw, 1.2rem);
   background: linear-gradient(
     90deg,
     rgba(247, 215, 116, 0.14) 0%,
@@ -1919,7 +1921,10 @@ footer {
   border-radius: 1rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   min-height: 100%;
-  padding: 1rem;
+  padding: var(--raffle-finished-shell-padding-block)
+    var(--raffle-finished-shell-padding-inline);
+  padding-bottom: calc(var(--raffle-finished-shell-padding-block) + 0.65rem);
+  /* * Este colchón extra evita que el botón "Ver sorteo" choque con el borde. */
 }
 
 .raffle-card--finished .raffle-card__flip {

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -599,122 +599,6 @@ main {
   box-shadow: var(--shadow-2);
 }
 
-/* -------- Raffle Card premium -------- */
-.raffle-card {
-  background: var(--surface-raffle);
-  border: 1px solid rgba(78, 164, 234, 0.18);
-  box-shadow: 0 18px 36px rgba(2, 12, 27, 0.1);
-  padding: 1.35rem 1.25rem 1.25rem;
-  overflow: hidden;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  transition: transform var(--transition-base),
-    box-shadow var(--transition-base), background var(--transition-base);
-}
-.raffle-card::after {
-  /* acento diagonal azul translúcido */
-  content: "";
-  position: absolute;
-  right: -40%;
-  top: -55%;
-  width: 120%;
-  height: 120%;
-  background: radial-gradient(
-    60% 60% at 60% 40%,
-    rgba(78, 164, 234, 0.16) 0%,
-    rgba(78, 164, 234, 0) 60%
-  );
-  transform: rotate(8deg);
-  pointer-events: none;
-}
-.raffle-card:hover {
-  background: linear-gradient(180deg, #ffffff 0%, #f2f8ff 100%);
-}
-
-/* Fecha / badge */
-.raffle-card__badge {
-  display: inline-block;
-  font-size: 0.78rem;
-  line-height: 1.2;
-  padding: 0.35rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(3, 23, 53, 0.06);
-  color: #031735;
-  border: 1px solid rgba(3, 23, 53, 0.16);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.8) inset;
-  margin-bottom: 0.25rem;
-}
-.raffle-card__badge--finished {
-  background: rgba(46, 160, 67, 0.12);
-  border-color: rgba(46, 160, 67, 0.25);
-  color: #1d6f36;
-}
-
-/* Título */
-.raffle-card__title {
-  font-size: 1.18rem;
-  font-weight: 700;
-  color: var(--brand-700);
-  letter-spacing: 0.01em;
-  margin-top: 0.2rem;
-}
-
-/* Countdown estilo “pills” */
-.countdown {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.8rem;
-  text-align: center;
-  margin-top: 0.35rem;
-}
-.countdown__item {
-  min-width: 3.6rem;
-  background: #fff;
-  border: 1px solid rgba(15, 40, 105, 0.08);
-  box-shadow: 0 6px 16px rgba(2, 12, 27, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8);
-  border-radius: 12px;
-  padding: 0.55rem 0.35rem;
-}
-.countdown__value {
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
-  font-size: clamp(1.6rem, 3.1vw + 0.5rem, 2.35rem);
-  font-weight: 800;
-  color: var(--brand-700);
-  line-height: 1.1;
-}
-.countdown__label {
-  margin-top: 0.1rem;
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-  color: var(--text-secondary);
-}
-
-@media (max-width: 480px) {
-  .countdown {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.6rem;
-  }
-}
-
-/* Estado finalizado */
-.raffle-card--finished {
-  border: none;
-  background: transparent;
-  box-shadow: none;
-  padding: 0;
-}
-.raffle-card--finished::after {
-  content: none;
-}
-.raffle-card--finished::before {
-  content: none;
-}
-
 /* ============================
    BOTONES
    ============================ */
@@ -1464,10 +1348,6 @@ footer {
 }
 
 /* Estados semánticos */
-.raffle-card--finished {
-  border-color: rgba(46, 160, 67, 0.28);
-  background: linear-gradient(180deg, #ffffff 0%, #f5fff6 100%);
-}
 .raffle-card--soon {
   /* < 60 min */
   --raffle-accent: #e59b2f; /* ámbar */
@@ -1489,11 +1369,6 @@ footer {
   border: 1px solid rgba(3, 23, 53, 0.16);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
   margin-bottom: 0.35rem;
-}
-.raffle-card__badge--finished {
-  background: rgba(46, 160, 67, 0.12);
-  border-color: rgba(46, 160, 67, 0.25);
-  color: #1d6f36;
 }
 
 /* Título */
@@ -1882,15 +1757,17 @@ footer {
   will-change: transform, opacity;
 }
 
-/* Finalizado — estilo dorado/premium coherente */
+/* Finalizado — el marco dorado vive en la "shell" para evitar duplicados */
 .raffle-card--finished {
-  border-color: rgba(218, 165, 32, 0.35); /* goldenrod */
-  background: radial-gradient(
-      60% 80% at 70% -10%,
-      rgba(255, 215, 0, 0.18) 0%,
-      rgba(255, 255, 255, 0) 60%
-    ),
-    linear-gradient(180deg, #ffffff 0%, #fff7df 100%); /* blanco → marfil dorado */
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  overflow: visible;
+}
+.raffle-card--finished::before,
+.raffle-card--finished::after {
+  content: none;
 }
 
 /* Badge cuando está finalizado: dorado suave */
@@ -1937,29 +1814,6 @@ footer {
     transform: translateY(56px) rotate(14deg);
     opacity: 0;
   }
-}
-
-.raffle-card--finished-horizontal {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem;
-  border-radius: 1rem;
-  background: linear-gradient(
-    90deg,
-    rgba(247, 215, 116, 0.15) 0%,
-    rgba(255, 255, 255, 0.9) 100%
-  );
-  border: 1px solid rgba(185, 141, 35, 0.28);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-}
-
-.raffle-card--finished-horizontal h3 {
-  font-size: 1.2rem;
-  font-weight: 700;
-  margin: 0;
 }
 
 /* Hace que el texto del ganador pueda truncar con elipsis */
@@ -2044,10 +1898,6 @@ footer {
 .raffle-card--finished[role="button"]:focus-visible {
   outline: 3px solid rgba(185, 141, 35, 0.45);
   outline-offset: 4px;
-}
-
-.raffle-card--finished {
-  overflow: visible;
 }
 
 .raffle-card__shell {

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -606,6 +606,12 @@ main {
   box-shadow: 0 18px 36px rgba(2, 12, 27, 0.1);
   padding: 1.35rem 1.25rem 1.25rem;
   overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base), background var(--transition-base);
 }
 .raffle-card::after {
   /* acento diagonal azul translúcido */
@@ -697,12 +703,15 @@ main {
 
 /* Estado finalizado */
 .raffle-card--finished {
-  border-color: transparent;
+  border: none;
   background: transparent;
   box-shadow: none;
   padding: 0;
 }
 .raffle-card--finished::after {
+  content: none;
+}
+.raffle-card--finished::before {
   content: none;
 }
 

--- a/sorteos-astavic/src/components/public/RaffleCard.js
+++ b/sorteos-astavic/src/components/public/RaffleCard.js
@@ -2,7 +2,7 @@
 // ! DECISIÓN DE DISEÑO: Centralizamos la tarjeta y su modal para mantener consistencia entre público y administración.
 // * Separamos efectos intensivos (countdown, transición y modal) en helpers locales para mejorar legibilidad y mantenimiento.
 // * La cara trasera alterna premios con animación accesible y sincroniza su altura para evitar cortes.
-// * Las tarjetas finalizadas omiten la clase `.card` para evitar bordes o sombras duplicadas en el contenedor giratorio.
+// * Encapsulamos el marco dorado en la "shell" interna para que rote con el contenido sin duplicar bordes ni sombras.
 // * El modo "preview" evita efectos y llamadas externas para ofrecer una representación segura en contextos administrativos.
 // -!- Riesgo: Los temporizadores dependen de window; en SSR deben aislarse antes de montar en cliente.
 import {
@@ -215,7 +215,7 @@ const RaffleCard = ({
       classes.unshift("card");
     }
     if (isFinished) {
-      classes.push("raffle-card--finished", "raffle-card--finished-horizontal");
+      classes.push("raffle-card--finished");
     } else if (isSoon) {
       classes.push("raffle-card--soon");
     }

--- a/sorteos-astavic/src/components/public/RaffleCard.js
+++ b/sorteos-astavic/src/components/public/RaffleCard.js
@@ -2,6 +2,7 @@
 // ! DECISIÓN DE DISEÑO: Centralizamos la tarjeta y su modal para mantener consistencia entre público y administración.
 // * Separamos efectos intensivos (countdown, transición y modal) en helpers locales para mejorar legibilidad y mantenimiento.
 // * El modo "preview" evita efectos y llamadas externas para ofrecer una representación segura en contextos administrativos.
+// * La cara trasera alterna premios con animación accesible para mantener claridad sin sacrificar usabilidad.
 // -!- Riesgo: Los temporizadores dependen de window; en SSR deben aislarse antes de montar en cliente.
 import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
@@ -27,6 +28,7 @@ const RaffleCard = ({
   const [isVanishing, setIsVanishing] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+  const [showPrizeSide, setShowPrizeSide] = useState(false);
 
   const finishedRef = useRef(isFinished);
   const openButtonRef = useRef(null);
@@ -97,6 +99,7 @@ const RaffleCard = ({
     setIsVanishing(false);
     setShowConfetti(false);
     setModalOpen(false);
+    setShowPrizeSide(false);
   }, [raffle.datetime, raffle.finished, raffle.id]);
 
   const participantsCount = useMemo(
@@ -117,6 +120,11 @@ const RaffleCard = ({
   const winners = useMemo(
     () => (Array.isArray(raffle.winners) ? raffle.winners : []),
     [raffle.winners]
+  );
+
+  const prizes = useMemo(
+    () => (Array.isArray(raffle.prizes) ? raffle.prizes : []),
+    [raffle.prizes]
   );
 
   const isSoon = useMemo(() => {
@@ -156,6 +164,39 @@ const RaffleCard = ({
         onClick: handleOpenModal,
       };
 
+  const handleFinishedCardClick = (event) => {
+    if (!isFinished || isPreviewMode) return;
+    const interactiveTarget = event.target.closest(
+      "button, a, input, select, textarea, [data-prevent-flip='true']"
+    );
+    if (interactiveTarget && interactiveTarget !== event.currentTarget) {
+      return;
+    }
+    setShowPrizeSide((previous) => !previous);
+  };
+
+  const handleFinishedCardKeyDown = (event) => {
+    if (!isFinished || isPreviewMode) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setShowPrizeSide((previous) => !previous);
+    }
+  };
+
+  const finishedInteractionProps =
+    !isFinished || isPreviewMode
+      ? {}
+      : {
+          onClick: handleFinishedCardClick,
+          onKeyDown: handleFinishedCardKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-pressed": showPrizeSide ? "true" : "false",
+          "aria-label": showPrizeSide
+            ? `Mostrar ganadores del sorteo ${raffle.title}`
+            : `Mostrar premios del sorteo ${raffle.title}`,
+        };
+
   return (
     <article
       aria-hidden={isPreviewMode ? "true" : undefined}
@@ -165,6 +206,8 @@ const RaffleCard = ({
           : isSoon
           ? " raffle-card--soon"
           : ""
+      }${
+        isFinished && showPrizeSide ? " raffle-card--show-prizes" : ""
       }${isVanishing ? " raffle-card--vanish" : ""}`}
       style={{
         ...(isFinished
@@ -177,136 +220,254 @@ const RaffleCard = ({
             }
           : {}),
       }}
+      {...finishedInteractionProps}
     >
       {isFinished ? (
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            alignItems: "stretch",
-            gap: "1rem",
-          }}
-        >
-          <div style={{ flex: "1 1 260px", minWidth: "220px" }}>
-            <span
-              className="raffle-card__badge raffle-card__badge--finished"
-              aria-label={`Fecha y hora del sorteo: ${formatDateEs(raffle.datetime)}`}
-              style={{ marginBottom: "0.5rem" }}
+        <div className="raffle-card__flip">
+          <div className="raffle-card__flip-inner">
+            <div
+              className="raffle-card__side raffle-card__side--front"
+              aria-hidden={showPrizeSide}
+              role="group"
+              aria-label={`Ganadores del sorteo ${raffle.title}`}
             >
-              <time dateTime={new Date(raffle.datetime).toISOString()}>
-                {formatDateEs(raffle.datetime)}
-              </time>
-            </span>
-
-            <h3 className="raffle-card__title" style={{ marginTop: "0.35rem" }}>
-              {raffle.title}
-            </h3>
-
-            {winners.length === 0 ? (
-              <div
-                style={{
-                  marginTop: "0.5rem",
-                  padding: "0.75rem",
-                  borderRadius: "0.85rem",
-                  border: "1px dashed rgba(185,141,35,0.35)",
-                  background:
-                    "linear-gradient(180deg, rgba(247,215,116,0.12) 0%, rgba(255,255,255,0.6) 100%)",
-                  color: "var(--text-secondary)",
-                  textAlign: "center",
-                  fontSize: "0.95rem",
-                }}
-              >
-                Próximamente publicaremos los ganadores.
-              </div>
-            ) : (
-              <ol
-                style={{
-                  listStyle: "none",
-                  margin: "0.6rem 0 0",
-                  padding: 0,
-                  display: "grid",
-                  gap: "0.6rem",
-                }}
-              >
-                {winners.map((winner, index) => (
-                  <li
-                    key={`${winner}-${index}`}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "space-between",
-                      gap: "0.6rem",
-                      padding: "0.55rem 0.7rem",
-                      borderRadius: "0.85rem",
-                      background:
-                        "linear-gradient(180deg, rgba(247,215,116,0.18) 0%, rgba(255,255,255,0.85) 100%)",
-                      border: "1px solid rgba(185,141,35,0.28)",
-                      boxShadow:
-                        "0 3px 10px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.65)",
-                    }}
+              <div className="raffle-card__side-content">
+                <div className="raffle-card__info">
+                  <span
+                    className="raffle-card__badge raffle-card__badge--finished"
+                    aria-label={`Fecha y hora del sorteo: ${formatDateEs(raffle.datetime)}`}
+                    style={{ marginBottom: "0.5rem" }}
                   >
-                    <span
+                    <time dateTime={new Date(raffle.datetime).toISOString()}>
+                      {formatDateEs(raffle.datetime)}
+                    </time>
+                  </span>
+
+                  <h3 className="raffle-card__title" style={{ marginTop: "0.35rem" }}>
+                    {raffle.title}
+                  </h3>
+
+                  {winners.length === 0 ? (
+                    <div
                       style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: "0.5rem",
-                        fontWeight: 700,
-                        color: "var(--brand-700)",
+                        marginTop: "0.5rem",
+                        padding: "0.75rem",
+                        borderRadius: "0.85rem",
+                        border: "1px dashed rgba(185,141,35,0.35)",
+                        background:
+                          "linear-gradient(180deg, rgba(247,215,116,0.12) 0%, rgba(255,255,255,0.6) 100%)",
+                        color: "var(--text-secondary)",
+                        textAlign: "center",
+                        fontSize: "0.95rem",
                       }}
                     >
-                      <span
-                        aria-hidden="true"
-                        style={{
-                          display: "inline-grid",
-                          placeItems: "center",
-                          width: "28px",
-                          height: "28px",
-                          borderRadius: 999,
-                          background:
-                            index === 0
-                              ? "linear-gradient(180deg,#f7d774 0%, #e9b949 100%)"
-                              : "linear-gradient(180deg,#fff1a6 0%, #ffe476 100%)",
-                          border:
-                            index === 0
-                              ? "1px solid rgba(185,141,35,0.45)"
-                              : "1px solid rgba(185,141,35,0.32)",
-                          color: "#3b2f0b",
-                          fontSize: "0.9rem",
-                          fontWeight: 800,
-                        }}
-                        title={`Puesto ${index + 1}`}
-                      >
-                        {index + 1}
-                      </span>
-                      {winner}
-                    </span>
-                  </li>
-                ))}
-              </ol>
-            )}
-          </div>
+                      Próximamente publicaremos los ganadores.
+                    </div>
+                  ) : (
+                    <ol
+                      style={{
+                        listStyle: "none",
+                        margin: "0.6rem 0 0",
+                        padding: 0,
+                        display: "grid",
+                        gap: "0.6rem",
+                      }}
+                    >
+                      {winners.map((winner, index) => (
+                        <li
+                          key={`${winner}-${index}`}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            gap: "0.6rem",
+                            padding: "0.55rem 0.7rem",
+                            borderRadius: "0.85rem",
+                            background:
+                              "linear-gradient(180deg, rgba(247,215,116,0.18) 0%, rgba(255,255,255,0.85) 100%)",
+                            border: "1px solid rgba(185,141,35,0.28)",
+                            boxShadow:
+                              "0 3px 10px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.65)",
+                          }}
+                        >
+                          <span
+                            style={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: "0.5rem",
+                              fontWeight: 700,
+                              color: "var(--brand-700)",
+                            }}
+                          >
+                            <span
+                              aria-hidden="true"
+                              style={{
+                                display: "inline-grid",
+                                placeItems: "center",
+                                width: "28px",
+                                height: "28px",
+                                borderRadius: 999,
+                                background:
+                                  index === 0
+                                    ? "linear-gradient(180deg,#f7d774 0%, #e9b949 100%)"
+                                    : "linear-gradient(180deg,#fff1a6 0%, #ffe476 100%)",
+                                border:
+                                  index === 0
+                                    ? "1px solid rgba(185,141,35,0.45)"
+                                    : "1px solid rgba(185,141,35,0.32)",
+                                color: "#3b2f0b",
+                                fontSize: "0.9rem",
+                                fontWeight: 800,
+                              }}
+                              title={`Puesto ${index + 1}`}
+                            >
+                              {index + 1}
+                            </span>
+                            {winner}
+                          </span>
+                        </li>
+                      ))}
+                    </ol>
+                  )}
+                </div>
 
-          <div
-            style={{
-              flex: "0 0 180px",
-              minWidth: "180px",
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "flex-end",
-              gap: "0.6rem",
-            }}
-          >
-            <button
-              ref={openButtonRef}
-              type="button"
-              className={viewButtonClass}
-              style={viewButtonStyle}
-              title="Ver información del sorteo"
-              aria-label={`Ver detalles del sorteo ${raffle.title}`}
-              {...viewButtonProps}
+                <div className="raffle-card__cta">
+                  <button
+                    ref={!showPrizeSide ? openButtonRef : null}
+                    type="button"
+                    className={viewButtonClass}
+                    style={viewButtonStyle}
+                    title="Ver información del sorteo"
+                    aria-label={`Ver detalles del sorteo ${raffle.title}`}
+                    data-prevent-flip="true"
+                    {...viewButtonProps}
+                  >
+                    Ver sorteo
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className="raffle-card__side raffle-card__side--back"
+              aria-hidden={!showPrizeSide}
+              role="group"
+              aria-label={`Premios del sorteo ${raffle.title}`}
             >
-              Ver sorteo
-            </button>
+              <div className="raffle-card__side-content">
+                <div className="raffle-card__info">
+                  <span
+                    className="raffle-card__badge raffle-card__badge--finished"
+                    aria-label={`Fecha y hora del sorteo: ${formatDateEs(raffle.datetime)}`}
+                    style={{ marginBottom: "0.5rem" }}
+                  >
+                    <time dateTime={new Date(raffle.datetime).toISOString()}>
+                      {formatDateEs(raffle.datetime)}
+                    </time>
+                  </span>
+
+                  <h3 className="raffle-card__title" style={{ marginTop: "0.35rem" }}>
+                    {raffle.title}
+                  </h3>
+
+                  {prizes.length === 0 ? (
+                    <div
+                      style={{
+                        marginTop: "0.5rem",
+                        padding: "0.75rem",
+                        borderRadius: "0.85rem",
+                        border: "1px dashed rgba(185,141,35,0.35)",
+                        background:
+                          "linear-gradient(180deg, rgba(247,215,116,0.12) 0%, rgba(255,255,255,0.6) 100%)",
+                        color: "var(--text-secondary)",
+                        textAlign: "center",
+                        fontSize: "0.95rem",
+                      }}
+                    >
+                      No hay premios registrados para este sorteo.
+                    </div>
+                  ) : (
+                    <ol
+                      style={{
+                        listStyle: "none",
+                        margin: "0.6rem 0 0",
+                        padding: 0,
+                        display: "grid",
+                        gap: "0.6rem",
+                      }}
+                    >
+                      {prizes.map((prize, index) => (
+                        <li
+                          key={`${prize?.title ?? "premio"}-${index}`}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "0.65rem",
+                            padding: "0.6rem 0.75rem",
+                            borderRadius: "0.85rem",
+                            background:
+                              "linear-gradient(180deg, rgba(247,215,116,0.18) 0%, rgba(255,255,255,0.85) 100%)",
+                            border: "1px solid rgba(185,141,35,0.28)",
+                            boxShadow:
+                              "0 3px 10px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.65)",
+                          }}
+                        >
+                          <span
+                            aria-hidden="true"
+                            style={{
+                              display: "inline-grid",
+                              placeItems: "center",
+                              width: "28px",
+                              height: "28px",
+                              borderRadius: 999,
+                              background:
+                                index === 0
+                                  ? "linear-gradient(180deg,#f7d774 0%, #e9b949 100%)"
+                                  : "linear-gradient(180deg,#fff1a6 0%, #ffe476 100%)",
+                              border:
+                                index === 0
+                                  ? "1px solid rgba(185,141,35,0.45)"
+                                  : "1px solid rgba(185,141,35,0.32)",
+                              color: "#3b2f0b",
+                              fontSize: "0.9rem",
+                              fontWeight: 800,
+                            }}
+                            title={`Premio ${index + 1}`}
+                          >
+                            {index + 1}
+                          </span>
+
+                          <span
+                            style={{
+                              fontWeight: 600,
+                              color: "var(--text-primary)",
+                              wordBreak: "break-word",
+                            }}
+                          >
+                            {prize?.title ?? "Premio sin nombre"}
+                          </span>
+                        </li>
+                      ))}
+                    </ol>
+                  )}
+                </div>
+
+                <div className="raffle-card__cta">
+                  <button
+                    ref={showPrizeSide ? openButtonRef : null}
+                    type="button"
+                    className={viewButtonClass}
+                    style={viewButtonStyle}
+                    title="Ver información del sorteo"
+                    aria-label={`Ver detalles del sorteo ${raffle.title}`}
+                    data-prevent-flip="true"
+                    {...viewButtonProps}
+                  >
+                    Ver sorteo
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       ) : (

--- a/sorteos-astavic/src/components/public/RaffleCard.js
+++ b/sorteos-astavic/src/components/public/RaffleCard.js
@@ -147,16 +147,7 @@ const RaffleCard = ({
   const viewButtonClass = isFinished
     ? "button button--gold"
     : "button button--primary";
-  const viewButtonStyle = isFinished
-    ? {
-        width: "100%",
-        background: "linear-gradient(180deg, #f7d774 0%, #e9b949 100%)",
-        color: "#3b2f0b",
-        boxShadow:
-          "0 10px 24px rgba(233,185,73,0.28), inset 0 1px 0 rgba(255,255,255,0.38)",
-        border: "1px solid rgba(185,141,35,0.35)",
-      }
-    : { width: "100%" };
+  const viewButtonStyle = isFinished ? undefined : { width: "100%" };
 
   const handleOpenModal = () => {
     if (isPreviewMode) return;

--- a/sorteos-astavic/src/components/public/RaffleCard.js
+++ b/sorteos-astavic/src/components/public/RaffleCard.js
@@ -2,6 +2,7 @@
 // ! DECISIÓN DE DISEÑO: Centralizamos la tarjeta y su modal para mantener consistencia entre público y administración.
 // * Separamos efectos intensivos (countdown, transición y modal) en helpers locales para mejorar legibilidad y mantenimiento.
 // * La cara trasera alterna premios con animación accesible y sincroniza su altura para evitar cortes.
+// * Las tarjetas finalizadas omiten la clase `.card` para evitar bordes o sombras duplicadas en el contenedor giratorio.
 // * El modo "preview" evita efectos y llamadas externas para ofrecer una representación segura en contextos administrativos.
 // -!- Riesgo: Los temporizadores dependen de window; en SSR deben aislarse antes de montar en cliente.
 import {
@@ -208,6 +209,25 @@ const RaffleCard = ({
             : `Mostrar premios del sorteo ${raffle.title}`,
         };
 
+  const cardClassName = useMemo(() => {
+    const classes = ["raffle-card"];
+    if (!isFinished) {
+      classes.unshift("card");
+    }
+    if (isFinished) {
+      classes.push("raffle-card--finished", "raffle-card--finished-horizontal");
+    } else if (isSoon) {
+      classes.push("raffle-card--soon");
+    }
+    if (isFinished && showPrizeSide) {
+      classes.push("raffle-card--show-prizes");
+    }
+    if (isVanishing) {
+      classes.push("raffle-card--vanish");
+    }
+    return classes.join(" ");
+  }, [isFinished, isSoon, isVanishing, showPrizeSide]);
+
   const measureActiveSide = useCallback(() => {
     if (!isFinished) return;
     const activeShell = showPrizeSide ? backShellRef.current : frontShellRef.current;
@@ -242,15 +262,7 @@ const RaffleCard = ({
   return (
     <article
       aria-hidden={isPreviewMode ? "true" : undefined}
-      className={`card raffle-card${
-        isFinished
-          ? " raffle-card--finished raffle-card--finished-horizontal"
-          : isSoon
-          ? " raffle-card--soon"
-          : ""
-      }${
-        isFinished && showPrizeSide ? " raffle-card--show-prizes" : ""
-      }${isVanishing ? " raffle-card--vanish" : ""}`}
+      className={cardClassName}
       {...finishedInteractionProps}
     >
       {isFinished ? (

--- a/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
@@ -43,6 +43,9 @@ test("alterna ganadores y premios al interactuar con la tarjeta finalizada", asy
   const shells = screen.getAllByTestId("raffle-card-shell");
   const [frontSide, backSide] = screen.getAllByRole("group", { hidden: true });
 
+  expect(cardToggle).toHaveClass("raffle-card--finished");
+  expect(cardToggle).not.toHaveClass("card");
+
   expect(shells).toHaveLength(2);
   expect(flipWrapper).toHaveAttribute("data-active-face", "front");
   expect(frontSide).toHaveAttribute(

--- a/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
@@ -42,6 +42,9 @@ test("alterna ganadores y premios al interactuar con la tarjeta finalizada", asy
   const flipWrapper = screen.getByTestId("raffle-card-flip");
   const shells = screen.getAllByTestId("raffle-card-shell");
   const [frontSide, backSide] = screen.getAllByRole("group", { hidden: true });
+  const frontCtaButton = within(frontSide).getByRole("button", {
+    name: /ver detalles del sorteo sorteo aniversario/i,
+  });
 
   expect(cardToggle).toHaveClass("raffle-card--finished");
   expect(cardToggle).not.toHaveClass("card");
@@ -63,6 +66,8 @@ test("alterna ganadores y premios al interactuar con la tarjeta finalizada", asy
   expect(frontSide).toHaveAttribute("aria-hidden", "false");
   expect(backSide).toHaveAttribute("aria-hidden", "true");
   expect(within(frontSide).getByText("Ana García")).toBeInTheDocument();
+  expect(frontCtaButton.style.width).toBe("");
+  expect(frontCtaButton).toHaveClass("button--gold");
 
   await userEvent.click(cardToggle);
 
@@ -71,6 +76,11 @@ test("alterna ganadores y premios al interactuar con la tarjeta finalizada", asy
   expect(backSide).toHaveAttribute("aria-hidden", "false");
   expect(flipWrapper).toHaveAttribute("data-active-face", "back");
   expect(within(backSide).getByText("Notebook Lenovo IdeaPad")).toBeInTheDocument();
+  const backCtaButton = within(backSide).getByRole("button", {
+    name: /ver detalles del sorteo sorteo aniversario/i,
+  });
+  expect(backCtaButton.style.width).toBe("");
+  expect(backCtaButton).toHaveClass("button--gold");
 
   cardToggle.focus();
   await userEvent.keyboard("{Enter}");

--- a/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
@@ -1,0 +1,88 @@
+// src/components/public/__tests__/RaffleCard.test.js
+// ! DECISIÓN DE DISEÑO: Validamos la interacción de volteo para asegurar accesibilidad y evitar regresiones visuales.
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RaffleCard from "../RaffleCard";
+
+jest.mock("../RaffleDetailsModal", () => () => null);
+
+const finishedRaffle = {
+  id: "raffle-finished-1",
+  title: "Sorteo aniversario",
+  description: "",
+  datetime: "2024-03-01T12:00:00.000Z",
+  participants: [],
+  winners: ["Ana García", "Luis Gómez"],
+  prizes: [
+    { title: "Notebook Lenovo IdeaPad" },
+    { title: "Auriculares inalámbricos" },
+  ],
+  finished: true,
+  winnersCount: 2,
+};
+
+const renderComponent = () => {
+  render(
+    <RaffleCard
+      raffle={finishedRaffle}
+      onMarkFinished={jest.fn()}
+      onRequestReminder={jest.fn()}
+      interactionMode="active"
+    />
+  );
+};
+
+test("alterna ganadores y premios al interactuar con la tarjeta finalizada", async () => {
+  renderComponent();
+
+  const cardToggle = screen.getByRole("button", {
+    name: /mostrar premios del sorteo sorteo aniversario/i,
+  });
+  const [frontSide, backSide] = screen.getAllByRole("group", { hidden: true });
+
+  expect(frontSide).toHaveAttribute(
+    "aria-label",
+    "Ganadores del sorteo Sorteo aniversario"
+  );
+  expect(backSide).toHaveAttribute(
+    "aria-label",
+    "Premios del sorteo Sorteo aniversario"
+  );
+
+  expect(frontSide).not.toBeNull();
+  expect(backSide).not.toBeNull();
+  expect(frontSide).toHaveAttribute("aria-hidden", "false");
+  expect(backSide).toHaveAttribute("aria-hidden", "true");
+  expect(within(frontSide).getByText("Ana García")).toBeInTheDocument();
+
+  await userEvent.click(cardToggle);
+
+  expect(cardToggle).toHaveAttribute("aria-pressed", "true");
+  expect(frontSide).toHaveAttribute("aria-hidden", "true");
+  expect(backSide).toHaveAttribute("aria-hidden", "false");
+  expect(within(backSide).getByText("Notebook Lenovo IdeaPad")).toBeInTheDocument();
+
+  cardToggle.focus();
+  await userEvent.keyboard("{Enter}");
+
+  expect(cardToggle).toHaveAttribute("aria-pressed", "false");
+  expect(frontSide).toHaveAttribute("aria-hidden", "false");
+  expect(within(frontSide).getByText("Ana García")).toBeInTheDocument();
+});
+
+test("conservar la vista de ganadores al abrir el detalle del sorteo", async () => {
+  renderComponent();
+
+  const cardToggle = screen.getByRole("button", {
+    name: /mostrar premios del sorteo sorteo aniversario/i,
+  });
+  const detailButtons = screen.getAllByRole("button", {
+    name: /ver detalles del sorteo sorteo aniversario/i,
+  });
+  const [frontSide] = screen.getAllByRole("group", { hidden: true });
+
+  await userEvent.click(detailButtons[0]);
+
+  expect(cardToggle).toHaveAttribute("aria-pressed", "false");
+  expect(frontSide).toHaveAttribute("aria-hidden", "false");
+});

--- a/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/RaffleCard.test.js
@@ -45,6 +45,7 @@ test("alterna ganadores y premios al interactuar con la tarjeta finalizada", asy
 
   expect(cardToggle).toHaveClass("raffle-card--finished");
   expect(cardToggle).not.toHaveClass("card");
+  expect(cardToggle).not.toHaveClass("raffle-card--finished-horizontal");
 
   expect(shells).toHaveLength(2);
   expect(flipWrapper).toHaveAttribute("data-active-face", "front");


### PR DESCRIPTION
## Summary
- add an interactive flip state for finished raffle cards to toggle winners and prizes while keeping the call to action centered
- style finished raffle cards with 3D flip presentation, focus treatment, and shared button layout
- cover the new behaviour with unit tests for the finished card toggle flow

## Testing
- CI=true npm test -- --watch=false
- npx eslint src --ext js,jsx

------
https://chatgpt.com/codex/tasks/task_e_68dc95a4507c83258700a544d7b89f03