### PR TITLE
Add accessible segmented navigation for public view

### DIFF
--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -612,6 +612,92 @@ main {
   }
 }
 
+/* Guía de participación */
+.participation-guide {
+  display: grid;
+  gap: 1.5rem;
+  padding: clamp(1.25rem, 1vw + 1rem, 2rem);
+  margin-bottom: 2.25rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(15, 40, 105, 0.12);
+  background: color-mix(in srgb, var(--surface) 80%, var(--brand-50) 20%);
+  box-shadow: 0 12px 30px rgba(2, 12, 27, 0.06);
+}
+
+.participation-guide__header {
+  display: grid;
+  gap: 0.65rem;
+  max-width: 48rem;
+}
+
+.participation-guide__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.1vw + 1.1rem, 1.8rem);
+}
+
+.participation-guide__intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.participation-guide__steps {
+  list-style-position: inside;
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  counter-reset: step;
+}
+
+.participation-guide__step {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.2rem 1.4rem 1.35rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(15, 40, 105, 0.1);
+  background: color-mix(in srgb, #ffffff 80%, var(--brand-50) 20%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.participation-guide__step-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.participation-guide__step-copy {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.98rem;
+}
+
+.participation-guide__action {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+}
+
+@media (min-width: 768px) {
+  .participation-guide__steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .participation-guide {
+    margin-bottom: 1.75rem;
+    padding: 1.1rem 1.2rem 1.4rem;
+  }
+
+  .participation-guide__step {
+    padding: 1rem 1.1rem 1.2rem;
+  }
+
+  .participation-guide__step-title {
+    font-size: 1rem;
+  }
+}
+
 /* ============================
    GRID & CARDS
    ============================ */

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -635,6 +635,11 @@ main {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-500) 35%, transparent);
 }
 
+.participation-guide[data-state="collapsed"] {
+  display: none !important;
+  visibility: hidden;
+}
+
 .participation-guide {
   display: grid;
   gap: 1.5rem;

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -613,6 +613,28 @@ main {
 }
 
 /* Guía de participación */
+.participation-guide__toggle-wrapper {
+  display: flex;
+  justify-content: flex-start;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.participation-guide__toggle {
+  align-self: flex-start;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.participation-guide__toggle[aria-expanded="true"] {
+  background: color-mix(in srgb, var(--brand-600) 12%, transparent);
+  border-color: color-mix(in srgb, var(--brand-600) 30%, transparent);
+  color: var(--brand-700);
+}
+
+.participation-guide__toggle:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-500) 35%, transparent);
+}
+
 .participation-guide {
   display: grid;
   gap: 1.5rem;
@@ -684,6 +706,10 @@ main {
 }
 
 @media (max-width: 600px) {
+  .participation-guide__toggle-wrapper {
+    margin: 1.25rem 0 0.5rem;
+  }
+
   .participation-guide {
     margin-bottom: 1.75rem;
     padding: 1.1rem 1.2rem 1.4rem;

--- a/sorteos-astavic/src/App.css
+++ b/sorteos-astavic/src/App.css
@@ -538,6 +538,60 @@ main {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.public-toolbar__segments {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 40, 105, 0.08);
+  background: color-mix(in srgb, var(--brand-50) 75%, #ffffff 25%);
+  border: 1px solid rgba(15, 40, 105, 0.14);
+  box-shadow: inset 0 1px 1px rgba(15, 40, 105, 0.08);
+}
+.segmented-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-width: 6.5rem;
+  padding: 0.45rem 1.1rem;
+  border: 0;
+  border-radius: calc(var(--radius-lg) - 0.25rem);
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+.segmented-button:hover {
+  background: rgba(15, 40, 105, 0.12);
+  color: var(--text-primary);
+}
+.segmented-button:focus-visible {
+  outline: 3px solid rgba(15, 77, 158, 0.6);
+  outline-offset: 2px;
+}
+.segmented-button--active,
+.segmented-button[aria-pressed="true"] {
+  background: var(--surface);
+  color: var(--brand-700);
+  box-shadow: 0 1px 6px rgba(15, 40, 105, 0.18);
+}
+.segmented-button--active:hover,
+.segmented-button[aria-pressed="true"]:hover {
+  background: color-mix(in srgb, #ffffff 90%, var(--brand-100) 10%);
+}
+.segmented-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
 }
 @media (max-width: 768px) {
   .public-toolbar {
@@ -545,7 +599,16 @@ main {
     align-items: stretch;
   }
   .public-toolbar__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .public-toolbar__segments {
+    width: 100%;
     justify-content: space-between;
+  }
+  .segmented-button {
+    flex: 1;
+    min-width: 0;
   }
 }
 

--- a/sorteos-astavic/src/App.js
+++ b/sorteos-astavic/src/App.js
@@ -99,6 +99,7 @@ const App = () => {
             finishedRaffles={finishedRaffles}
             onMarkFinished={markFinished}
             onRegisterSubscriber={registerSubscriber}
+            onRouteChange={navigate}
             route={route}
           />
         )}

--- a/sorteos-astavic/src/App.test.js
+++ b/sorteos-astavic/src/App.test.js
@@ -39,7 +39,10 @@ const submitLogin = async (user) => {
 
 test('renderiza la vista publica con el titulo Sorteos', () => {
   renderWithToast(<App />);
-  const heading = screen.getByRole('heading', { name: /Sorteos/i });
+  const heading = screen.getByRole('heading', {
+    level: 1,
+    name: /sorteos activos/i,
+  });
   expect(heading).toBeInTheDocument();
 });
 

--- a/sorteos-astavic/src/components/Header.js
+++ b/sorteos-astavic/src/components/Header.js
@@ -7,8 +7,9 @@ import PropTypes from "prop-types";
 import useBodyScrollLock from "../hooks/useBodyScrollLock";
 import useFocusTrap from "../hooks/useFocusTrap";
 
-const NAV_ITEMS = [
+const MOBILE_NAV_ITEMS = [
   { target: "public", href: "#/", label: "Inicio" },
+  { target: "all", href: "#/todos", label: "Todos los sorteos" },
   { target: "finished", href: "#/finalizados", label: "Sorteos finalizados" },
   // "Administración" ya no se lista acá para desktop; en mobile se maneja aparte según isAdmin
 ];
@@ -35,8 +36,6 @@ const Header = ({
   const burgerButtonRef = useRef(null);
   const menuWasOpenRef = useRef(false);
   const menuId = "primary-menu";
-
-  const DESKTOP_ITEMS = NAV_ITEMS; // sin admin aquí
 
   const handleNavigate = (target) => (event) => {
     event.preventDefault();
@@ -137,7 +136,7 @@ const Header = ({
                 </button>
               </div>
               <nav aria-label="Navegación móvil" className="app-header__mobile-nav">
-                {NAV_ITEMS.map(({ target, href, label }) => (
+                {MOBILE_NAV_ITEMS.map(({ target, href, label }) => (
                   <a
                     key={`mobile-${target}`}
                     href={href}
@@ -199,26 +198,7 @@ const Header = ({
         </a>
 
         {/* Desktop nav */}
-        {!isMobile && (
-          <nav
-            className="app-header__nav app-nav"
-            aria-label="Navegación principal"
-          >
-            {DESKTOP_ITEMS.map(({ target, href, label }) => (
-              <a
-                key={target}
-                href={href}
-                className={`nav-link${
-                  currentRoute === target ? " is-active" : ""
-                }`}
-                aria-current={currentRoute === target ? "page" : undefined}
-                onClick={handleNavigate(target)}
-              >
-                {label}
-              </a>
-            ))}
-          </nav>
-        )}
+        {/* Desktop: sin enlaces redundantes cuando los controla PublicView */}
 
         <div className="app-header__actions">
           {/* Desktop: acciones admin a la derecha */}
@@ -286,7 +266,7 @@ BurgerIcon.propTypes = { open: PropTypes.bool };
 BurgerIcon.defaultProps = { open: false };
 
 Header.propTypes = {
-  currentRoute: PropTypes.oneOf(["public", "finished", "admin"]).isRequired,
+  currentRoute: PropTypes.oneOf(["public", "finished", "admin", "all"]).isRequired,
   onNavigate: PropTypes.func.isRequired,
   logoSrc: PropTypes.string,
   isAdmin: PropTypes.bool, // <- NUEVO

--- a/sorteos-astavic/src/components/__tests__/Header.test.js
+++ b/sorteos-astavic/src/components/__tests__/Header.test.js
@@ -69,9 +69,15 @@ describe("Header - menú móvil accesible", () => {
 
     await user.tab();
     const secondLink = within(dialog).getByRole("link", {
-      name: /sorteos finalizados/i,
+      name: /todos los sorteos/i,
     });
     expect(secondLink).toHaveFocus();
+
+    await user.tab();
+    const thirdLink = within(dialog).getByRole("link", {
+      name: /sorteos finalizados/i,
+    });
+    expect(thirdLink).toHaveFocus();
 
     await user.tab();
     const adminLink = within(dialog).getByRole("link", {

--- a/sorteos-astavic/src/components/public/ParticipationGuide.js
+++ b/sorteos-astavic/src/components/public/ParticipationGuide.js
@@ -1,17 +1,24 @@
 // src/components/public/ParticipationGuide.js
 // ! DECISIÓN DE DISEÑO: Guiamos el flujo de participación con pasos accionables para reducir fricción y mejorar conversión.
 // * El bloque refuerza accesibilidad usando lista ordenada y encabezados jerárquicos.
+// * Permitimos plegar el contenido por defecto para reducir ruido visual sin sacrificar orientación.
 // -!- Riesgo: Si se agregan nuevas acciones asincrónicas deberán sincronizarse estados de carga para evitar solapamientos.
 import PropTypes from "prop-types";
 
 const ParticipationGuide = ({
+  id,
+  isVisible,
   onOpenReminder,
   onViewFinished,
   showFinishedShortcut,
 }) => (
   <section
-    className="participation-guide anim-up"
+    id={id}
+    className={`participation-guide anim-up${
+      isVisible ? " participation-guide--expanded" : ""
+    }`}
     aria-labelledby="participation-guide-heading"
+    hidden={!isVisible}
   >
     <div className="participation-guide__header">
       <h2 id="participation-guide-heading" className="participation-guide__title">
@@ -72,12 +79,16 @@ const ParticipationGuide = ({
 );
 
 ParticipationGuide.propTypes = {
+  id: PropTypes.string,
+  isVisible: PropTypes.bool,
   onOpenReminder: PropTypes.func.isRequired,
   onViewFinished: PropTypes.func,
   showFinishedShortcut: PropTypes.bool,
 };
 
 ParticipationGuide.defaultProps = {
+  id: undefined,
+  isVisible: true,
   onViewFinished: undefined,
   showFinishedShortcut: false,
 };

--- a/sorteos-astavic/src/components/public/ParticipationGuide.js
+++ b/sorteos-astavic/src/components/public/ParticipationGuide.js
@@ -1,0 +1,85 @@
+// src/components/public/ParticipationGuide.js
+// ! DECISIÓN DE DISEÑO: Guiamos el flujo de participación con pasos accionables para reducir fricción y mejorar conversión.
+// * El bloque refuerza accesibilidad usando lista ordenada y encabezados jerárquicos.
+// -!- Riesgo: Si se agregan nuevas acciones asincrónicas deberán sincronizarse estados de carga para evitar solapamientos.
+import PropTypes from "prop-types";
+
+const ParticipationGuide = ({
+  onOpenReminder,
+  onViewFinished,
+  showFinishedShortcut,
+}) => (
+  <section
+    className="participation-guide anim-up"
+    aria-labelledby="participation-guide-heading"
+  >
+    <div className="participation-guide__header">
+      <h2 id="participation-guide-heading" className="participation-guide__title">
+        Cómo participar en los sorteos
+      </h2>
+      <p className="participation-guide__intro">
+        Seguí estos pasos para inscribirte, recibir alertas oportunas y enterarte
+        de los resultados sin perderte ninguna instancia.
+      </p>
+    </div>
+    <ol className="participation-guide__steps">
+      <li className="participation-guide__step">
+        <h3 className="participation-guide__step-title">Explorá y elegí</h3>
+        <p className="participation-guide__step-copy">
+          Revisá la fecha, los premios y los requisitos de cada sorteo antes de
+          sumarte para confirmar que se ajusta a lo que buscás.
+        </p>
+      </li>
+      <li className="participation-guide__step">
+        <h3 className="participation-guide__step-title">Solicitá un recordatorio</h3>
+        <p className="participation-guide__step-copy">
+          Configurá un aviso por correo para recibir una alerta previa al cierre
+          de inscripciones y preparar tu participación con tiempo.
+        </p>
+        <button
+          type="button"
+          className="button button--primary participation-guide__action"
+          onClick={onOpenReminder}
+        >
+          Configurar recordatorio
+        </button>
+      </li>
+      <li className="participation-guide__step">
+        <h3 className="participation-guide__step-title">Seguí el sorteo en vivo</h3>
+        <p className="participation-guide__step-copy">
+          Volvé el día y horario indicados para acompañar la transmisión o la
+          actualización en vivo y conocer a las personas ganadoras.
+        </p>
+      </li>
+      <li className="participation-guide__step">
+        <h3 className="participation-guide__step-title">Revisá los resultados</h3>
+        <p className="participation-guide__step-copy">
+          Consultá el historial para confirmar si fuiste seleccionado y ver los
+          detalles de entrega publicados por el equipo organizador.
+        </p>
+        {showFinishedShortcut ? (
+          <button
+            type="button"
+            className="button button--ghost participation-guide__action"
+            onClick={onViewFinished}
+          >
+            Ver sorteos finalizados
+          </button>
+        ) : null}
+      </li>
+    </ol>
+  </section>
+);
+
+ParticipationGuide.propTypes = {
+  onOpenReminder: PropTypes.func.isRequired,
+  onViewFinished: PropTypes.func,
+  showFinishedShortcut: PropTypes.bool,
+};
+
+ParticipationGuide.defaultProps = {
+  onViewFinished: undefined,
+  showFinishedShortcut: false,
+};
+
+export default ParticipationGuide;

--- a/sorteos-astavic/src/components/public/ParticipationGuide.js
+++ b/sorteos-astavic/src/components/public/ParticipationGuide.js
@@ -2,6 +2,7 @@
 // ! DECISIÓN DE DISEÑO: Guiamos el flujo de participación con pasos accionables para reducir fricción y mejorar conversión.
 // * El bloque refuerza accesibilidad usando lista ordenada y encabezados jerárquicos.
 // * Permitimos plegar el contenido por defecto para reducir ruido visual sin sacrificar orientación.
+// * Mantenemos el nodo en DOM con data-state para animaciones futuras, pero lo marcamos hidden y aria-hidden cuando procede.
 // -!- Riesgo: Si se agregan nuevas acciones asincrónicas deberán sincronizarse estados de carga para evitar solapamientos.
 import PropTypes from "prop-types";
 
@@ -18,7 +19,10 @@ const ParticipationGuide = ({
       isVisible ? " participation-guide--expanded" : ""
     }`}
     aria-labelledby="participation-guide-heading"
+    aria-hidden={!isVisible}
+    data-state={isVisible ? "expanded" : "collapsed"}
     hidden={!isVisible}
+    data-testid="participation-guide"
   >
     <div className="participation-guide__header">
       <h2 id="participation-guide-heading" className="participation-guide__title">
@@ -90,7 +94,7 @@ ParticipationGuide.propTypes = {
 
 ParticipationGuide.defaultProps = {
   id: undefined,
-  isVisible: true,
+  isVisible: false,
   onViewFinished: undefined,
   showFinishedShortcut: false,
 };

--- a/sorteos-astavic/src/components/public/ParticipationGuide.js
+++ b/sorteos-astavic/src/components/public/ParticipationGuide.js
@@ -25,23 +25,25 @@ const ParticipationGuide = ({
         Cómo participar en los sorteos
       </h2>
       <p className="participation-guide__intro">
-        Seguí estos pasos para inscribirte, recibir alertas oportunas y enterarte
-        de los resultados sin perderte ninguna instancia.
+        Seguí estos pasos para mantenerte informado: ASTAVIC gestiona las
+        inscripciones y avisos oficiales, vos podés consultar fechas, premios y
+        resultados sin perderte ninguna instancia.
       </p>
     </div>
     <ol className="participation-guide__steps">
       <li className="participation-guide__step">
-        <h3 className="participation-guide__step-title">Explorá y elegí</h3>
+        <h3 className="participation-guide__step-title">Explorá los sorteos</h3>
         <p className="participation-guide__step-copy">
-          Revisá la fecha, los premios y los requisitos de cada sorteo antes de
-          sumarte para confirmar que se ajusta a lo que buscás.
+          Revisá fecha, premios y participantes designados para cada sorteo. No
+          necesitás inscribirte: el equipo de ASTAVIC administra la selección de
+          personas participantes.
         </p>
       </li>
       <li className="participation-guide__step">
-        <h3 className="participation-guide__step-title">Solicitá un recordatorio</h3>
+        <h3 className="participation-guide__step-title">Activá recordatorios</h3>
         <p className="participation-guide__step-copy">
-          Configurá un aviso por correo para recibir una alerta previa al cierre
-          de inscripciones y preparar tu participación con tiempo.
+          Configurá un aviso por correo para que te notifiquemos antes del
+          sorteo y estés listo para seguir la transmisión o revisar novedades.
         </p>
         <button
           type="button"
@@ -54,15 +56,15 @@ const ParticipationGuide = ({
       <li className="participation-guide__step">
         <h3 className="participation-guide__step-title">Seguí el sorteo en vivo</h3>
         <p className="participation-guide__step-copy">
-          Volvé el día y horario indicados para acompañar la transmisión o la
-          actualización en vivo y conocer a las personas ganadoras.
+          Volvé el día y horario indicados para acompañar la transmisión o las
+          actualizaciones en vivo que compartimos en la plataforma.
         </p>
       </li>
       <li className="participation-guide__step">
         <h3 className="participation-guide__step-title">Revisá los resultados</h3>
         <p className="participation-guide__step-copy">
-          Consultá el historial para confirmar si fuiste seleccionado y ver los
-          detalles de entrega publicados por el equipo organizador.
+          Consultá el historial para ver ganadores y detalles de entrega que
+          publica ASTAVIC una vez finalizada cada instancia.
         </p>
         {showFinishedShortcut ? (
           <button

--- a/sorteos-astavic/src/components/public/PublicView.js
+++ b/sorteos-astavic/src/components/public/PublicView.js
@@ -75,7 +75,8 @@ const PublicView = ({
     }
     return {
       title: "Sorteos activos",
-      subtitle: "Participá en los sorteos vigentes y pedí recordatorios por correo.",
+      subtitle:
+        "Informate sobre los sorteos vigentes, sus premios y participantes confirmados. Pedí recordatorios por correo.",
       emptyTitle: "No hay sorteos publicados en este momento.",
       emptySubtitle: "Publicaremos nuevos sorteos en cuanto estén disponibles.",
     };

--- a/sorteos-astavic/src/components/public/PublicView.js
+++ b/sorteos-astavic/src/components/public/PublicView.js
@@ -2,7 +2,7 @@
 // ! DECISIÓN DE DISEÑO: Los feedback del público utilizan el ToastContext para brindar mensajes consistentes y accesibles.
 // * Separamos responsabilidades en componentes auxiliares para mantener este contenedor declarativo.
 // * Controlamos la navegación local con un segmento accesible que evita recargas y preserva el foco.
-// * Integramos una guía paso a paso para educar a nuevas personas participantes sin sobrecargar el layout.
+// * Integramos una guía plegable para educar a nuevas personas participantes sin sobrecargar el layout.
 // -!- Riesgo: En producción debería persistirse la suscripción en un backend confiable y con doble opt-in.
 import { useCallback, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
@@ -24,6 +24,7 @@ const PublicView = ({
   const [email, setEmail] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [reminder, setReminder] = useState({ open: false, raffle: null });
+  const [isGuideVisible, setGuideVisible] = useState(false);
   const emailFieldRef = useRef(null);
   const { showToast } = useToast();
   const normalizedEmail = useMemo(() => sanitizeEmail(email), [email]);
@@ -115,6 +116,14 @@ const PublicView = ({
   }, [handleRouteSelection]);
 
   const reminderRaffle = reminder.raffle;
+  const participationGuideId = "participation-guide-section";
+  const guideToggleLabel = isGuideVisible
+    ? "Ocultar guía de participación"
+    : "Ver guía de participación";
+
+  const toggleGuideVisibility = useCallback(() => {
+    setGuideVisible((previous) => !previous);
+  }, []);
 
   const handleSubmitSubscription = useCallback(async (event) => {
     event.preventDefault();
@@ -204,7 +213,20 @@ const PublicView = ({
               </button>
             </div>
           </div>
+          <div className="participation-guide__toggle-wrapper anim-up">
+            <button
+              type="button"
+              className="button button--ghost participation-guide__toggle"
+              aria-expanded={isGuideVisible}
+              aria-controls={participationGuideId}
+              onClick={toggleGuideVisibility}
+            >
+              {guideToggleLabel}
+            </button>
+          </div>
           <ParticipationGuide
+            id={participationGuideId}
+            isVisible={isGuideVisible}
             onOpenReminder={handleGeneralReminder}
             onViewFinished={hasFinishedRaffles ? handleViewFinished : undefined}
             showFinishedShortcut={hasFinishedRaffles && !isFinishedRoute}

--- a/sorteos-astavic/src/components/public/PublicView.js
+++ b/sorteos-astavic/src/components/public/PublicView.js
@@ -30,16 +30,23 @@ const PublicView = ({
     [normalizedEmail]
   );
   const isFinishedRoute = route === "finished";
+  const isAllRoute = route === "all";
   const segmentOptions = useMemo(
     () => [
+      { label: "Todos", value: "all" },
       { label: "Activos", value: "public" },
       { label: "Finalizados", value: "finished" },
     ],
     []
   );
   const visibleRaffles = useMemo(
-    () => (isFinishedRoute ? finishedRaffles : activeRaffles),
-    [isFinishedRoute, finishedRaffles, activeRaffles]
+    () => {
+      if (isAllRoute) {
+        return [...activeRaffles, ...finishedRaffles];
+      }
+      return isFinishedRoute ? finishedRaffles : activeRaffles;
+    },
+    [activeRaffles, finishedRaffles, isAllRoute, isFinishedRoute]
   );
   const visibleCount = visibleRaffles.length;
 
@@ -53,13 +60,22 @@ const PublicView = ({
           "Ni bien cerremos un sorteo, vas a ver el listado completo acá.",
       };
     }
+    if (isAllRoute) {
+      return {
+        title: "Todos los sorteos",
+        subtitle: "Explorá el historial completo de sorteos y sus resultados.",
+        emptyTitle: "No encontramos sorteos publicados todavía.",
+        emptySubtitle:
+          "Cuando publiquemos sorteos vas a verlos acá, activos o finalizados.",
+      };
+    }
     return {
       title: "Sorteos activos",
       subtitle: "Participá en los sorteos vigentes y pedí recordatorios por correo.",
       emptyTitle: "No hay sorteos publicados en este momento.",
       emptySubtitle: "Publicaremos nuevos sorteos en cuanto estén disponibles.",
     };
-  }, [isFinishedRoute]);
+  }, [isAllRoute, isFinishedRoute]);
 
   const handleCloseReminder = useCallback(() => {
     setReminder({ open: false, raffle: null });
@@ -213,7 +229,7 @@ PublicView.propTypes = {
   onMarkFinished: PropTypes.func,
   onRegisterSubscriber: PropTypes.func.isRequired,
   onRouteChange: PropTypes.func,
-  route: PropTypes.oneOf(["public", "finished"]),
+  route: PropTypes.oneOf(["public", "finished", "all"]),
 };
 
 PublicView.defaultProps = {

--- a/sorteos-astavic/src/components/public/PublicView.js
+++ b/sorteos-astavic/src/components/public/PublicView.js
@@ -2,11 +2,13 @@
 // ! DECISIÓN DE DISEÑO: Los feedback del público utilizan el ToastContext para brindar mensajes consistentes y accesibles.
 // * Separamos responsabilidades en componentes auxiliares para mantener este contenedor declarativo.
 // * Controlamos la navegación local con un segmento accesible que evita recargas y preserva el foco.
+// * Integramos una guía paso a paso para educar a nuevas personas participantes sin sobrecargar el layout.
 // -!- Riesgo: En producción debería persistirse la suscripción en un backend confiable y con doble opt-in.
 import { useCallback, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import RaffleGrid from "./RaffleGrid";
 import ReminderDialog from "./ReminderDialog";
+import ParticipationGuide from "./ParticipationGuide";
 import rafflePropType from "./rafflePropType";
 import { useToast } from "../../context/ToastContext";
 import { isValidEmail, sanitizeEmail } from "../../utils/validation";
@@ -31,6 +33,7 @@ const PublicView = ({
   );
   const isFinishedRoute = route === "finished";
   const isAllRoute = route === "all";
+  const hasFinishedRaffles = finishedRaffles.length > 0;
   const segmentOptions = useMemo(
     () => [
       { label: "Todos", value: "all" },
@@ -106,6 +109,10 @@ const PublicView = ({
     },
     [onRouteChange, route]
   );
+
+  const handleViewFinished = useCallback(() => {
+    handleRouteSelection("finished");
+  }, [handleRouteSelection]);
 
   const reminderRaffle = reminder.raffle;
 
@@ -197,6 +204,11 @@ const PublicView = ({
               </button>
             </div>
           </div>
+          <ParticipationGuide
+            onOpenReminder={handleGeneralReminder}
+            onViewFinished={hasFinishedRaffles ? handleViewFinished : undefined}
+            showFinishedShortcut={hasFinishedRaffles && !isFinishedRoute}
+          />
           <RaffleGrid
             raffles={visibleRaffles}
             allowMarkFinished={!isFinishedRoute}

--- a/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
@@ -47,6 +47,9 @@ test("muestra copy de sorteos activos y contador accesible", () => {
   expect(
     screen.getByText(/hay 1 sorteo/i)
   ).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: /cómo participar en los sorteos/i })
+  ).toBeInTheDocument();
 });
 
 test("permite alternar entre vistas desde el segmento", async () => {
@@ -99,6 +102,34 @@ test("muestra copy combinado y conteo acumulado en pestaña todos", () => {
     screen.getByRole("heading", { name: /todos los sorteos/i })
   ).toBeInTheDocument();
   expect(screen.getByText(/hay 2 sorteos/i)).toBeInTheDocument();
+});
+
+test("la guía explica pasos clave y ofrece accesos directos", async () => {
+  const onRouteChange = jest.fn();
+  setup({
+    finishedRaffles: [{ ...raffleSample, id: "raffle-3", finished: true }],
+    onRouteChange,
+  });
+
+  expect(
+    screen.getByText(/Configurá un aviso por correo/i)
+  ).toBeInTheDocument();
+
+  await userEvent.click(
+    screen.getByRole("button", { name: /configurar recordatorio/i })
+  );
+
+  expect(
+    await screen.findByRole("dialog", { name: /recibí recordatorios y resultados/i })
+  ).toBeInTheDocument();
+
+  const finishedShortcut = screen.getByRole("button", {
+    name: /ver sorteos finalizados/i,
+  });
+
+  await userEvent.click(finishedShortcut);
+
+  expect(onRouteChange).toHaveBeenCalledWith("finished");
 });
 
 test("valida correo antes de registrar suscripción", async () => {

--- a/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
@@ -39,7 +39,7 @@ beforeEach(() => {
   mockShowToast.mockClear();
 });
 
-test("muestra copy de sorteos activos y contador accesible", () => {
+test("muestra copy de sorteos activos y mantiene la guía plegada", () => {
   setup();
   expect(
     screen.getByRole("heading", { name: /sorteos activos/i })
@@ -48,8 +48,10 @@ test("muestra copy de sorteos activos y contador accesible", () => {
     screen.getByText(/hay 1 sorteo/i)
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("heading", { name: /cómo participar en los sorteos/i })
-  ).toBeInTheDocument();
+    screen.queryByRole("heading", { name: /cómo participar en los sorteos/i })
+  ).not.toBeInTheDocument();
+  const toggle = screen.getByRole("button", { name: /ver guía de participación/i });
+  expect(toggle).toHaveAttribute("aria-expanded", "false");
 });
 
 test("permite alternar entre vistas desde el segmento", async () => {
@@ -104,13 +106,20 @@ test("muestra copy combinado y conteo acumulado en pestaña todos", () => {
   expect(screen.getByText(/hay 2 sorteos/i)).toBeInTheDocument();
 });
 
-test("la guía explica pasos clave y ofrece accesos directos", async () => {
+test("permite desplegar la guía y ofrece accesos directos", async () => {
   const onRouteChange = jest.fn();
   setup({
     finishedRaffles: [{ ...raffleSample, id: "raffle-3", finished: true }],
     onRouteChange,
   });
 
+  const toggle = screen.getByRole("button", { name: /ver guía de participación/i });
+  await userEvent.click(toggle);
+
+  expect(toggle).toHaveAttribute("aria-expanded", "true");
+  expect(
+    screen.getByRole("heading", { name: /cómo participar en los sorteos/i })
+  ).toBeInTheDocument();
   expect(
     screen.getByText(/Configurá un aviso por correo/i)
   ).toBeInTheDocument();

--- a/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
@@ -27,11 +27,12 @@ const setup = (overrides = {}) => {
     finishedRaffles: [],
     onMarkFinished: jest.fn(),
     onRegisterSubscriber: jest.fn(),
+    onRouteChange: jest.fn(),
     route: "public",
     ...overrides,
   };
-  render(<PublicView {...props} />);
-  return props;
+  const view = render(<PublicView {...props} />);
+  return { props, ...view };
 };
 
 beforeEach(() => {
@@ -46,6 +47,30 @@ test("muestra copy de sorteos activos y contador accesible", () => {
   expect(
     screen.getByText(/hay 1 sorteo/i)
   ).toBeInTheDocument();
+});
+
+test("permite alternar entre sorteos activos y finalizados desde el segmento", async () => {
+  const onRouteChange = jest.fn();
+  const { props, rerender } = setup({ onRouteChange });
+
+  const finishedTab = screen.getByRole("button", { name: /finalizados/i });
+  expect(finishedTab).toHaveAttribute("aria-pressed", "false");
+
+  await userEvent.click(finishedTab);
+
+  expect(onRouteChange).toHaveBeenCalledWith("finished");
+
+  rerender(<PublicView {...props} route="finished" />);
+
+  expect(
+    screen.getByRole("button", { name: /finalizados/i })
+  ).toHaveAttribute("aria-pressed", "true");
+  expect(
+    screen.getByRole("button", { name: /finalizados/i })
+  ).toHaveAttribute("aria-current", "page");
+  expect(
+    screen.getByRole("button", { name: /activos/i })
+  ).not.toHaveAttribute("aria-current");
 });
 
 test("valida correo antes de registrar suscripción", async () => {

--- a/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
+++ b/sorteos-astavic/src/components/public/__tests__/PublicView.test.js
@@ -49,12 +49,16 @@ test("muestra copy de sorteos activos y contador accesible", () => {
   ).toBeInTheDocument();
 });
 
-test("permite alternar entre sorteos activos y finalizados desde el segmento", async () => {
+test("permite alternar entre vistas desde el segmento", async () => {
   const onRouteChange = jest.fn();
   const { props, rerender } = setup({ onRouteChange });
 
+  const allTab = screen.getByRole("button", { name: /todos/i });
   const finishedTab = screen.getByRole("button", { name: /finalizados/i });
   expect(finishedTab).toHaveAttribute("aria-pressed", "false");
+
+  await userEvent.click(allTab);
+  expect(onRouteChange).toHaveBeenCalledWith("all");
 
   await userEvent.click(finishedTab);
 
@@ -71,6 +75,30 @@ test("permite alternar entre sorteos activos y finalizados desde el segmento", a
   expect(
     screen.getByRole("button", { name: /activos/i })
   ).not.toHaveAttribute("aria-current");
+
+  rerender(<PublicView {...props} route="all" />);
+
+  expect(screen.getByRole("button", { name: /todos/i })).toHaveAttribute(
+    "aria-current",
+    "page"
+  );
+  expect(screen.getByRole("button", { name: /todos/i })).toHaveAttribute(
+    "aria-pressed",
+    "true"
+  );
+});
+
+test("muestra copy combinado y conteo acumulado en pestaña todos", () => {
+  setup({
+    route: "all",
+    activeRaffles: [raffleSample],
+    finishedRaffles: [{ ...raffleSample, id: "raffle-2", finished: true }],
+  });
+
+  expect(
+    screen.getByRole("heading", { name: /todos los sorteos/i })
+  ).toBeInTheDocument();
+  expect(screen.getByText(/hay 2 sorteos/i)).toBeInTheDocument();
 });
 
 test("valida correo antes de registrar suscripción", async () => {

--- a/sorteos-astavic/src/hooks/useHashRoute.js
+++ b/sorteos-astavic/src/hooks/useHashRoute.js
@@ -5,18 +5,21 @@ const ROUTES = {
   PUBLIC: "public",
   ADMIN: "admin",
   FINISHED: "finished",
+  ALL: "all",
 };
 
 const HASH_BY_ROUTE = {
   [ROUTES.PUBLIC]: "#/",
   [ROUTES.ADMIN]: "#/admin",
   [ROUTES.FINISHED]: "#/finalizados",
+  [ROUTES.ALL]: "#/todos",
 };
 
 const parseRouteFromHash = (hash) => {
   if (!hash) return ROUTES.PUBLIC;
   if (hash.startsWith("#/admin")) return ROUTES.ADMIN;
   if (hash.startsWith("#/finalizados")) return ROUTES.FINISHED;
+  if (hash.startsWith("#/todos")) return ROUTES.ALL;
   return ROUTES.PUBLIC;
 };
 
@@ -59,6 +62,7 @@ export const useHashRoute = () => {
       isAdminRoute: route === ROUTES.ADMIN,
       isFinishedRoute: route === ROUTES.FINISHED,
       isPublicRoute: route === ROUTES.PUBLIC,
+      isAllRoute: route === ROUTES.ALL,
     }),
     [route]
   );


### PR DESCRIPTION
## Summary
- expose the hash navigate callback to the public view so the section toggle can change routes
- add an accessible segmented control to switch between active and finished raffles and adjust supporting styles
- extend public view tests to cover navigation through the new segmented control

## Testing
- CI=true npm test -- --watch=false
- npx eslint src --max-warnings=0