### PR TITLE
Evitar remontaje de vista pública al alternar filtros

### DIFF
--- a/sorteos-astavic/src/App.js
+++ b/sorteos-astavic/src/App.js
@@ -1,4 +1,6 @@
 // src/App.js
+// ! DECISIÓN DE DISEÑO: Evitamos remontar la vista pública al alternar segmentos compartidos
+// ! para conservar estado local y no recalcular tarjetas innecesarias.
 
 import { useCallback, useRef } from "react";
 import Header from "./components/Header";
@@ -66,6 +68,8 @@ const App = () => {
     }
   }, []);
 
+  const mainContentKey = route === "admin" ? "admin" : "public";
+
   return (
     <div className="app-shell">
       <a
@@ -78,7 +82,7 @@ const App = () => {
       <Header currentRoute={route} onNavigate={navigate} isAdmin={isAdmin} />
       <main
         id={MAIN_CONTENT_ID}
-        key={route}
+        key={mainContentKey}
         className="anim-fade-in"
         ref={mainContentRef}
         tabIndex={-1}


### PR DESCRIPTION
## Summary
- evita remontar la vista pública al alternar entre segmentos de sorteos para reutilizar elementos compartidos
- agrega una prueba que garantiza la persistencia del correo suscrito al cambiar de segmento

## Testing
- CI=true npm test -- --watch=false
- npx eslint src --ext js

------
https://chatgpt.com/codex/tasks/task_e_68e08c27feb88325a45a2643828dbd44